### PR TITLE
Fixed throughput calculation

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -195,8 +195,8 @@
     function addChartPoint(time, timeDiff, dataIn, dataOut) {
         //console.log('addChartPoint', time, timeDiff, dataIn, dataOut);
         
-        dataIn = dataIn / 100000 / timeDiff;
-        dataOut = dataOut / 100000 / timeDiff;
+        dataIn = (dataIn*8) / (1024*1024) / timeDiff;
+        dataOut = (dataOut*8) / (1024*1024) / timeDiff;
         
         if (chartData) {
             //console.log('chartData', time, dataIn, dataOut);


### PR DESCRIPTION
Corrected the band calculation.
SNMP gets data in OCTETS, to get the port band we need to transform these OCTETS into bits, so multiply by 8.
The code shows in Mbps, so we multiplied (1024 * 1024) to transpose bps to Mbps.

When I tested the code I noticed that the band was not correct, when investigating the code I found a simplistic method of calculation that approached but did not present the correct value.